### PR TITLE
fix(ckbpage): correct tokenomics facts and fix broken wallet link

### DIFF
--- a/public/locales/en/ckbpage.json
+++ b/public/locales/en/ckbpage.json
@@ -1,12 +1,12 @@
 {
   "title": "1 CKB = 1 Byte",
-  "slogan": "CKByte (CKB) is the native cryptocurrency of Common Knowledge Base. It’s used for paying transaction fees and storing data, where holding one CKB permits users to store one byte of data on Nervos’ base layer.",
+  "slogan": "CKByte (CKB) is the native cryptocurrency of Common Knowledge Base. It's used for paying transaction fees and storing data, where holding one CKB permits users to store one byte of data on Nervos' base layer.",
   "tokenomics": {
     "title": "CKB Tokenomics",
     "description": {
-      "text1": "The CKB token launched with an initial supply of 33.6 billion coins, 8.4 billion of which were burned soon thereafter. The base issuance is 33.6 billion coins per year and halves every four years until it hits zero, whereas the fixed secondary issuance is 1.344 billion. Check out the detailed CKB supply structure and issuance schedule <1>here</1>.",
+      "text1": "The CKB token launched with an initial supply of 33.6 billion coins, 8.4 billion of which were burned soon thereafter. The base issuance totals 33.6 billion coins and halves every four years until it hits zero, whereas the fixed secondary issuance is 1.344 billion per year. Check out the detailed CKB supply structure and issuance schedule <1>here</1>.",
       "text2": "Miners receive CKB rewards from two sources: the base and secondary issuance. The secondary issuance depends on state occupation, where miners receive half of the secondary issuance reward if half of the circulating CKB coins are used to store state. When the base issuance eventually ends, miners will keep earning \"state rent\" income from the secondary issuance, regardless of transaction demand, which ensures they're incentivized to secure the blockchain long-term.",
-      "text3": "CKB holders receive rewards from the secondary issuance by locking their coins in the <1>Nervos DAO</1> smart contract, which is a mechanism incentivizes the removal of unnecessary data, ensuring long-term manageability of the blockchain"
+      "text3": "CKB holders receive rewards from the secondary issuance by locking their coins in the <1>Nervos DAO</1> smart contract, which is a mechanism that incentivizes the removal of unnecessary data, ensuring long-term manageability of the blockchain"
     }
   },
   "get_ckb": {

--- a/src/pages/ckbpage/index.page.tsx
+++ b/src/pages/ckbpage/index.page.tsx
@@ -44,8 +44,8 @@ const CkbPage: NextPage<PageProps> = ({ contributors, author }) => {
           <p>
             <Trans t={t} i18nKey="tokenomics.description.text1">
               The CKB token launched with an initial supply of 33.6 billion coins, 8.4 billion of which were burned soon
-              thereafter. The base issuance is 33.6 billion coins per year and halves every four years until it hits
-              zero, whereas the fixed secondary issuance is 1.344 billion. Check out the detailed CKB supply structure
+              thereafter. The base issuance totals 33.6 billion coins and halves every four years until it hits
+              zero, whereas the fixed secondary issuance is 1.344 billion per year. Check out the detailed CKB supply structure
               and issuance schedule&nbsp;
               <StyledLink
                 href="https://medium.com/@m.quinn/a-detailed-description-of-nervos-ckb-supply-and-issuance-1d55c4b101f9"
@@ -67,7 +67,7 @@ const CkbPage: NextPage<PageProps> = ({ contributors, author }) => {
               <StyledLink href="https://medium.com/nervosnetwork/nervos-dao-explained-95e33898b1c" colored underline>
                 Nervos DAO
               </StyledLink>
-              &nbsp; smart contract, which is a mechanism incentivizes the removal of unnecessary data, ensuring long-term manageability of the blockchain.
+              &nbsp; smart contract, which is a mechanism that incentivizes the removal of unnecessary data, ensuring long-term manageability of the blockchain.
             </Trans>
           </p>
         </>
@@ -84,7 +84,7 @@ const CkbPage: NextPage<PageProps> = ({ contributors, author }) => {
               this list
             </StyledLink>
             . However, consider transferring and holding your CKB using a non-custodial cryptocurrency
-            <StyledLink href="https://nervos-official-website.vercel.app/wallets" colored underline>
+            <StyledLink href="/wallets" colored underline>
               wallet
             </StyledLink>
             , as holding it on centralized exchanges is risky.


### PR DESCRIPTION
## Summary

Fixes issues reported in [talk.nervos.org/t/ckbpage/10377](https://talk.nervos.org/t/ckbpage/10377).

## Changes

### 1. Correct base issuance description (`public/locales/en/ckbpage.json` + `src/pages/ckbpage/index.page.tsx`)

**Before:** "The base issuance is 33.6 billion coins **per year**"

**After:** "The base issuance **totals** 33.6 billion coins"

Per [official docs](https://docs.nervos.org/docs/mining/rewards#base-reward): *"Base Reward: 33.6 billion CKBytes **in total**, halved every 4 years."* The 33.6 billion is the total primary issuance, not an annual rate. Added "per year" to the secondary issuance where it is correct ("1.344 billion per year").

Note: Chinese translation (`zh/ckbpage.json`) was already correct — it uses "总量" (total).

### 2. Fix broken wallet link (`src/pages/ckbpage/index.page.tsx`)

**Before:** `https://nervos-official-website.vercel.app/wallets` (Vercel preview domain)

**After:** `/wallets` (relative path to the production page)

### 3. Fix grammar (`public/locales/en/ckbpage.json` + `src/pages/ckbpage/index.page.tsx`)

**Before:** "which is a mechanism incentivizes"

**After:** "which is a mechanism **that** incentivizes"